### PR TITLE
enhanced tests and metrics collection

### DIFF
--- a/scripts/test/.gitignore
+++ b/scripts/test/.gitignore
@@ -1,1 +1,28 @@
 job_8465870
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+dist/
+build/
+*.egg-info/
+
+# Virtual environments
+venv/
+env/
+*.env
+
+# IDEs and editors
+.idea/
+.vscode/
+
+# Miscellaneous
+*.DS_Store
+*.log
+*.bak
+*.tmp
+
+job_output
+metrics

--- a/scripts/test/driver.py
+++ b/scripts/test/driver.py
@@ -1,92 +1,97 @@
 import subprocess
 import time
-import statistics
 import os
 import sys
+import csv
 
-if len(sys.argv) < 2:
-    print("Usage: python get_arg.py <iterations>")
-    sys.exit(1)
-
-its = int(sys.argv[1])
-output_dir = os.environ.get('JOB_OUTPUT_DIR')
-scripts_dir = os.environ.get('SCRIPTS_DIR')
-
-if output_dir is None:
-    print("output_dir not found")
-    sys.exit(1)
-
-print(f"output_dir: {output_dir}")
-
-view_script = 'view_test.py'
-target_script = 'target_test.py'
-script_stdout = 'script.output'
-
-if os.path.exists(script_stdout):
-    os.remove(script_stdout)
-
-
-def gen_output_folders(folder, iterations):
-    for i in range(iterations):
-        try:
-            final_dir = output_dir + "/" + folder + "/" + str(i + 1)
-            os.makedirs(final_dir, exist_ok=False)
-        except Exception as e:
-            print(f"Failed to create directory '{final_dir}': {e}")
-
-def get_all_metrics(folder, iteration):
-    final_dir = output_dir + '/' + folder + '/' + str(iteration)
-    command = [scripts_dir + '/' + "filesystem_ioctl"  + '/' + 'get_all_metrics.sh', final_dir]
-    try:
-        result = subprocess.run(command, capture_output=True, text=True, check=True)
-    except subprocess.CalledProcessError as e:
-        print(e.stdout)
-        if e.stderr:
-            print(e.stderr)
+def check_environment_variables():
+    required_vars = [
+        'TEST_ID', 'HOSTNAME', 'SCRIPTS_DIR',
+        'TEST_OUTPUT_DIR', 'TEST_OUTPUT_VIEW_DIR', 'TEST_OUTPUT_TARGET_DIR',
+        'TEST_TIME_VIEW_PATH', 'TEST_TIME_TARGET_PATH',
+        'VIEW_SCRIPT_PATH', 'TARGET_SCRIPT_PATH', 'WHAT_TO_TEST'
+    ]
+    for var in required_vars:
+        if not os.environ.get(var):
+            print(f"Error: Environment variable {var} is not set.")
             sys.exit(1)
+
+def get_all_metrics(folder):
+    reset_fs_script = os.path.join(os.environ.get('SCRIPTS_DIR'), 'filesystem_ioctl', 'get_all_metrics.sh')
+    command = [reset_fs_script, folder]
+    try:
+        subprocess.run(command, capture_output=True, text=True, check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"{os.environ.get('HOSTNAME')}-{os.environ.get('TEST_ID')}: {e.stdout}")
+        if e.stderr:
+            print(f"{os.environ.get('HOSTNAME')}-{os.environ.get('TEST_ID')}: {e.stderr}")
+        sys.exit(1)
 
 def reset_fs():
-    command = [scripts_dir + '/' + "filesystem_ioctl"  + '/' + 'reset_fs.sh']
+    reset_fs_script = os.path.join(os.environ.get('SCRIPTS_DIR'), 'filesystem_ioctl', 'get_all_metrics.sh')
+    command = [reset_fs_script]
     try:
         result = subprocess.run(command, capture_output=True, text=True, check=True)
     except subprocess.CalledProcessError as e:
         print(e.stdout)
         if e.stderr:
             print(e.stderr)
-            sys.exit(1)
+        sys.exit(1)
 
-def run_script(folder, script_name, iterations):
-    execution_times = []
-    script_output = output_dir + "/" + script_stdout
-    print(f'{script_name} - start run')
-    with open(script_output, 'a') as f:
-        for i in range(iterations):
-            iteration = i + 1
-            print(f'{script_name} - iteration: {iteration}')
-            start_time = time.time()
-            subprocess.run(['python3', script_name], stdout=f)
-            end_time = time.time()
-            execution_times.append(end_time - start_time)
+def run_script(get_metrics, script_path, output_folder, time_output_path):
+    hostname = os.environ.get('HOSTNAME')
+    test_id = os.environ.get('TEST_ID')
+    print(f'{hostname}-{test_id}: {script_path} - start run')
+    script_stdout = 'script.output'
+    script_output = os.path.join(output_folder, script_stdout)
 
-            if folder == "view":
-                get_all_metrics(folder, iteration)
-                #reset_fs()
+    try:
+        start_time = time.time()
+        print(f"{hostname}-{test_id}: start_time: {start_time}")
+        with open(script_output, 'a') as f:
+            subprocess.run(['python3', script_path], stdout=f, check=True)
+        end_time = time.time()
+        print(f"{hostname}-{test_id}: end_time: {end_time}")
+        total_time = end_time - start_time
+        print(f"{hostname}-{test_id}: total time - {total_time}")
 
-    total_time = sum(execution_times)
-    if iterations >= 2:
-        std_dev = statistics.stdev(execution_times)
+        data = [hostname, test_id, start_time, end_time, total_time]
+        with open(time_output_path, "w", newline='') as t_file:
+            t_writer = csv.writer(t_file)
+            t_writer.writerow(["hostname", "test_id", "start_time", "end_time", "total_time"])
+            t_writer.writerow(data)
 
-    print("====================================================")
-    print("=                     METRICS                      =")
-    print("====================================================")
-    print(f'{script_name} - Total time: {total_time}')
-    if iterations >= 2:
-        print(f'{script_name} - Stddev time: {std_dev}')
-    print("====================================================")
+        if get_metrics:
+            get_all_metrics(output_folder)
 
+    except subprocess.CalledProcessError as e:
+        print(f"Error running {script_path}: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"Unexpected error: {e}")
+        sys.exit(1)
 
-gen_output_folders("view", its)
+def main():
+    check_environment_variables()
 
-#reset_fs()
-run_script("view", view_script, its)
-run_script("target", target_script, its)
+    what_to_test = os.environ.get('WHAT_TO_TEST')
+    if what_to_test not in ["view_and_target", "view", "target"]:
+        print("Invalid value for WHAT_TO_TEST.")
+        sys.exit(1)
+
+    scripts_dir = os.environ.get('SCRIPTS_DIR')
+
+    if what_to_test in ["view_and_target", "view"]:
+        view_script_path = os.environ.get('VIEW_SCRIPT_PATH')
+        view_output_dir = os.environ.get('TEST_OUTPUT_VIEW_DIR')
+        test_time_view_path = os.environ.get('TEST_TIME_VIEW_PATH')
+        run_script(True, view_script_path, view_output_dir, test_time_view_path)
+
+    if what_to_test in ["view_and_target", "target"]:
+        target_script_path = os.environ.get('TARGET_SCRIPT_PATH')
+        target_output_dir = os.environ.get('TEST_OUTPUT_TARGET_DIR')
+        test_time_target_path = os.environ.get('TEST_TIME_TARGET_PATH')
+        run_script(False, target_script_path, target_output_dir, test_time_target_path)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test/get_metrics.py
+++ b/scripts/test/get_metrics.py
@@ -1,0 +1,107 @@
+import csv
+import os
+import glob
+import sys
+import numpy as np
+import pandas as pd
+
+def find_csv_files(search_directory, pattern):
+    return glob.glob(os.path.join(search_directory, pattern), recursive=True)
+
+def check_env_variable(variable_name):
+    value = os.environ.get(variable_name)
+    if not value:
+        print(f"{variable_name} not found in environment variables.")
+        sys.exit(1)
+    return value
+
+def parse_csv(file_path, csv_output_path, csv_header):
+    header_written = False
+    if not os.path.exists(file_path):
+        print(f"File {file_path} not found. Skipping...")
+        return
+
+    with open(file_path, mode='r') as file:
+        reader = csv.reader(file)
+        header = next(reader)
+        print(f"Header: {csv_header}")
+        for row in reader:
+            print(f"Row: {row}")
+            with open(csv_output_path, "a", newline='') as t_file:
+                t_writer = csv.writer(t_file)
+                if not header_written:
+                    t_writer.writerow(csv_header)
+                    header_written = True
+                t_writer.writerow(row)
+
+def calculate_statistics(csv_file, top_perc, bot_perc):
+    if not os.path.exists(csv_file):
+        print(f"File {csv_file} not found. Skipping metrics calculation.")
+        return
+
+    # Read CSV into a pandas DataFrame
+    df = pd.read_csv(csv_file)
+
+    # Convert 'total_time' column to numeric (in case it's not already)
+    df['total_time'] = pd.to_numeric(df['total_time'], errors='coerce')
+
+    # Calculate statistics
+    mean = df['total_time'].mean()
+    std_dev = df['total_time'].std()
+    top_perc_res = np.percentile(df['total_time'], 100 - top_perc)
+    bot_perc_res = np.percentile(df['total_time'], bot_perc)
+
+    # Print statistics
+    print(f"mean total_time: {mean}")
+    print(f"standard deviation total_time: {std_dev}")
+    print(f"largest {top_perc}% of total_time: {top_perc_res}")
+    print(f"smallest {bot_perc}% of total_time: {bot_perc_res}")
+
+def main(search_directory):
+    if len(sys.argv) != 2:
+        print("Usage: get_metrics.py <directory>")
+        sys.exit(1)
+
+    # Get environment variables
+    view_csv_output_path = check_env_variable('CSV_VIEW_OUTPUT_PATH')
+    target_csv_output_path = check_env_variable('CSV_TARGET_OUTPUT_PATH')
+
+    # Define CSV header
+    csv_header = ["hostname", "test_id", "start_time", "end_time", "total_time"]
+
+    # Find CSV files
+    target_csv_files = find_csv_files(search_directory, '**/target/**/*.csv')
+    view_csv_files = find_csv_files(search_directory, '**/csv/**/*.csv')
+
+    # Print found CSV files
+    print("Target CSV files found:")
+    for csv_file in target_csv_files:
+        print(csv_file)
+    print("\nView CSV files found:")
+    for csv_file in view_csv_files:
+        print(csv_file)
+
+    # Parse CSV files
+    print("\nParsing view CSV files:")
+    for csv_file in view_csv_files:
+        print(f"Parsing file: {csv_file}")
+        parse_csv(csv_file, view_csv_output_path, csv_header)
+
+    print("\nParsing target CSV files:")
+    for csv_file in target_csv_files:
+        print(f"Parsing file: {csv_file}")
+        parse_csv(csv_file, target_csv_output_path, csv_header)
+
+    # Calculate statistics
+    print(f"\nGenerating statistics for: {target_csv_output_path}")
+    print("======================= TARGET METRICS =======================")
+    calculate_statistics(target_csv_output_path, 5, 5)
+
+    print(f"\nGenerating statistics for: {view_csv_output_path}")
+    print("======================= VIEW METRICS =======================")
+    calculate_statistics(view_csv_output_path, 5, 5)
+
+    print("===============================================================")
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/scripts/test/requirements.txt
+++ b/scripts/test/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+numpy

--- a/scripts/test/run_get_metrics.sh
+++ b/scripts/test/run_get_metrics.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+SCRIPT=$(realpath -s "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
+ENV=$SCRIPTPATH/../env.sh
+
+if [ ! -f $ENV ]
+then
+	echo "failed to find ENV: $ENV"
+	exit 1
+fi
+
+source $ENV
+
+export SEARCH_DIR="$SCRIPTS_DIR"
+export OUTPUT_DIR=$SCRIPTS_DIR/test/metrics
+export CSV_VIEW_OUTPUT_PATH=$OUTPUT_DIR/view_metrics.csv
+export CSV_TARGET_OUTPUT_PATH=$OUTPUT_DIR/target_metrics.csv
+
+echo "deleting prev metrics folder"
+rm -r $OUTPUT_DIR
+mkdir -p $OUTPUT_DIR
+
+# Run the Python script with the provided directory parameter
+python3 $SCRIPTS_DIR/test/get_metrics.py "$SEARCH_DIR"

--- a/scripts/test/run_tests.sh
+++ b/scripts/test/run_tests.sh
@@ -40,8 +40,8 @@ mkdir -p $TEST_OUTPUT_TARGET_DIR
 export VIEW_SCRIPT_PATH=$SCRIPTS_DIR/test/view_test.py
 export TARGET_SCRIPT_PATH=$SCRIPTS_DIR/test/target_test.py
 
-# module use /soft/preview-modulefiles/24.086.0
-# module load frameworks/2024.04.15.002
+module use /soft/preview-modulefiles/24.086.0
+module load frameworks/2024.04.15.002
 
 python3 driver.py | tee "$TEST_OUTPUT_DIR/driver_output.stdout"
 

--- a/scripts/test/run_tests.sh
+++ b/scripts/test/run_tests.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 #set -o nounset
 
-ITERATIONS=1
+# SET TO WHAT SCRIPTS YOU WANT TO TEST
+#   Options:
+#     1. view
+#     2. target
+#     3. view_and_target
+export WHAT_TO_TEST=target
 
 SCRIPT=$(realpath -s "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
@@ -15,12 +20,31 @@ fi
 
 source $ENV
 
-export JOB_ID=$(shuf -i 1-9999999 -n 1)
-mkdir "$(pwd)/job_${JOB_ID}"
-export JOB_OUTPUT_DIR="$(pwd)/job_${JOB_ID}"
+export TEST_ID=$(shuf -i 1-9999999 -n 1)
+export HOSTNAME=$(hostname)
 
-module use /soft/preview-modulefiles/24.086.0
-module load frameworks/2024.04.15.002
+export TEST_TOP_DIR=$SCRIPTS_DIR/test/test_output
+export TEST_ID_TOP_DIR=$TEST_TOP_DIR
+export TEST_OUTPUT_DIR="$TEST_ID_TOP_DIR/$(hostname)/${TEST_ID}"
+export TEST_OUTPUT_VIEW_DIR=$TEST_OUTPUT_DIR/view
+export TEST_OUTPUT_TARGET_DIR=$TEST_OUTPUT_DIR/target
 
-python3 driver.py $ITERATIONS | tee "$JOB_OUTPUT_DIR/driver_output.stdout"
+export TEST_TIME_FILENAME=output_time.csv
+export TEST_TIME_VIEW_PATH=$TEST_OUTPUT_VIEW_DIR/$TEST_TIME_FILENAME
+export TEST_TIME_TARGET_PATH=$TEST_OUTPUT_TARGET_DIR/$TEST_TIME_FILENAME
+
+echo "removing prev job output"
+rm -r $TEST_OUTPUT_DIR
+
+mkdir -p $TEST_OUTPUT_DIR
+mkdir -p $TEST_OUTPUT_VIEW_DIR
+mkdir -p $TEST_OUTPUT_TARGET_DIR
+
+export VIEW_SCRIPT_PATH=$SCRIPTS_DIR/test/view_test.py
+export TARGET_SCRIPT_PATH=$SCRIPTS_DIR/test/target_test.py
+
+# module use /soft/preview-modulefiles/24.086.0
+# module load frameworks/2024.04.15.002
+
+python3 driver.py | tee "$TEST_OUTPUT_DIR/driver_output.stdout"
 

--- a/scripts/test/run_tests.sh
+++ b/scripts/test/run_tests.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 #set -o nounset
 
-ITERATIONS=1
+# SET TO WHAT SCRIPTS YOU WANT TO TEST
+#   Options:
+#     1. view
+#     2. target
+#     3. view_and_target
+export WHAT_TO_TEST=target
 
 SCRIPT=$(realpath -s "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
@@ -15,12 +20,28 @@ fi
 
 source $ENV
 
-export JOB_ID=$(shuf -i 1-9999999 -n 1)
-mkdir "$(pwd)/job_${JOB_ID}"
-export JOB_OUTPUT_DIR="$(pwd)/job_${JOB_ID}"
+export TEST_ID=$(shuf -i 1-9999999 -n 1)
+export HOSTNAME=$(hostname)
 
-module use /soft/preview-modulefiles/24.086.0
-module load frameworks/2024.04.15.002
+export TEST_TOP_DIR=$SCRIPTS_DIR/test/test_output
+export TEST_ID_TOP_DIR=$TEST_TOP_DIR
+export TEST_OUTPUT_DIR="$TEST_ID_TOP_DIR/$(hostname)/${TEST_ID}"
+export TEST_OUTPUT_VIEW_DIR=$TEST_OUTPUT_DIR/view
+export TEST_OUTPUT_TARGET_DIR=$TEST_OUTPUT_DIR/target
 
-python3 driver.py $ITERATIONS | tee "$JOB_OUTPUT_DIR/driver_output.stdout"
+export TEST_TIME_FILENAME=output_time.csv
+export TEST_TIME_VIEW_PATH=$TEST_OUTPUT_VIEW_DIR/$TEST_TIME_FILENAME
+export TEST_TIME_TARGET_PATH=$TEST_OUTPUT_TARGET_DIR/$TEST_TIME_FILENAME
+
+mkdir -p $TEST_OUTPUT_DIR
+mkdir -p $TEST_OUTPUT_VIEW_DIR
+mkdir -p $TEST_OUTPUT_TARGET_DIR
+
+export VIEW_SCRIPT_PATH=$SCRIPTS_DIR/test/view_test.py
+export TARGET_SCRIPT_PATH=$SCRIPTS_DIR/test/target_test.py
+
+# module use /soft/preview-modulefiles/24.086.0
+# module load frameworks/2024.04.15.002
+
+python3 driver.py | tee "$TEST_OUTPUT_DIR/driver_output.stdout"
 

--- a/scripts/test/target_test.py
+++ b/scripts/test/target_test.py
@@ -4,9 +4,7 @@ import os
 print("target_test script")
 
 packages_dir = os.environ['PY_PACKAGES_DIR']
-
 print(f"packages dir: {packages_dir}")
-
 sys.path.insert(0, packages_dir)
 
 import numpy

--- a/scripts/test/view_test.py
+++ b/scripts/test/view_test.py
@@ -7,9 +7,7 @@ view_dir = os.environ['VIEW_DIR']
 packages_dir = os.environ['PY_PACKAGES_DIR']
 
 packages = view_dir + packages_dir
-
 print(f"packages dir: {packages}")
-
 sys.path.insert(0, packages)
 
 import numpy


### PR DESCRIPTION
Per rank csv files are generated with the the following information:

1. hostname
2. test_id
3. start_time
4. end_time
5. total_time

The new [run_get_metrics.sh](https://github.com/argonne-lcf/copper/blob/5e67b6f06597fbf54d8a75a7ed871f0b73c835cd/scripts/test/run_get_metrics.sh) can be used to parse these target/view csv files and generate the top and bottom 5% total time as well as mean and std dev.

Make sure you set this before running tests [ (scripts/test/run_tests.sh):](https://github.com/argonne-lcf/copper/blob/5e67b6f06597fbf54d8a75a7ed871f0b73c835cd/scripts/test/run_tests.sh#L9)
Options:
1. view
6. target
7. view_and_target
```
export WHAT_TO_TEST=target
```