### PR TITLE
Skip large files

### DIFF
--- a/scripts/test/driver.py
+++ b/scripts/test/driver.py
@@ -88,8 +88,8 @@ def run_script(view_dir, packages_dir, view, get_metrics, script_path, output_fo
             t_writer.writerow(["hostname", "test_id", "start_time", "end_time", "total_time"])
             t_writer.writerow(data)
 
-        if get_metrics:
-            get_all_metrics(output_folder)
+        # if get_metrics:
+        #    get_all_metrics(output_folder)
 
     except subprocess.CalledProcessError as e:
         print(f"Error running {script_path}: {e}")

--- a/src/fs/constants.h
+++ b/src/fs/constants.h
@@ -17,6 +17,7 @@ class Constants {
     static inline std::optional<std::string> log_output_dir{std::nullopt};
     static inline std::string my_hostname;
     static inline int es{1};
+    static inline int max_cacheable_byte_size{1048576};
 
     // clang-format off
     static inline std::string usage{"cu_fuse <FUSE_PARAMS> -tpath <ABS_TARGET_PATH> "
@@ -24,6 +25,8 @@ class Constants {
                                                             "-log_level <0-6> "
                                                             "-log_type <file/stdout/file_and_stdout> "
                                                             "-log_output_dir <ABS_LOG_OUTPUT_DIR_PATH>"
+                                                            "-es <NUM_EXECUTION_STREAMS>"
+                                                            "-max_cacheable_byte_size <MAX_CACHEABLE_BYTE_SIZE>"
                                                             " <ABS_VIEW_PATH>"};
     // clang-format on
 

--- a/src/fs/cu_fuse.cpp
+++ b/src/fs/cu_fuse.cpp
@@ -26,7 +26,6 @@ namespace tl = thallium;
 
 #define CU_FUSE_RPC_DATA "cu_fuse_rpc_data"
 #define CU_FUSE_RPC_METADATA "cu_fuse_rpc_metadata"
-#define MAX_FILE_CACHE_SIZE 1048576
 
 static int cu_fuse_getattr(const char* path_, struct stat* stbuf, struct fuse_file_info* fi) {
     LOG(DEBUG) << " " << std::endl;
@@ -72,7 +71,7 @@ static int cu_fuse_read(const char* path_, char* buf, const size_t size, const o
     auto md_entry = CacheTables::md_cache_table.get(path_string);
     if(md_entry.has_value()) {
         struct stat* md_st = (struct stat*)md_entry.value()->get_vec().data();
-        if(md_st->st_size >= MAX_FILE_CACHE_SIZE) {
+        if(md_st->st_size >= Constants::max_cacheable_byte_size) {
             LOG(INFO) << "file larger than max cacheable size... going to lustre" << std::endl;
 
             int fd = open(path_string.c_str(), O_RDONLY);

--- a/src/fs/util.cpp
+++ b/src/fs/util.cpp
@@ -44,7 +44,7 @@ std::vector<std::string> Util::process_args(const int argc, const char* argv[]) 
         if(original_string_args[i] == "--plus") {
             Constants::fill_dir_plus = FUSE_FILL_DIR_PLUS;
         } else if(original_string_args[i] == "-tpath") {
-            if(i + 2 >= original_string_args.size()) {
+            if(i + 1 >= original_string_args.size()) {
                 LOG(FATAL) << Constants::usage << std::endl;
                 throw std::runtime_error("no argument after -tpath");
             }
@@ -53,7 +53,7 @@ std::vector<std::string> Util::process_args(const int argc, const char* argv[]) 
             LOG(DEBUG) << "-tpath was found: " << Constants::target_path.value() << std::endl;
             i += 2;
         } else if(original_string_args[i] == "-vpath") {
-            if(i + 2 >= original_string_args.size()) {
+            if(i + 1 >= original_string_args.size()) {
                 LOG(FATAL) << Constants::usage << std::endl;
                 throw std::runtime_error("no argument after -vpath");
             }
@@ -62,7 +62,7 @@ std::vector<std::string> Util::process_args(const int argc, const char* argv[]) 
             LOG(DEBUG) << "-vpath was found: " << Constants::view_path.value() << std::endl;
             i += 2;
         } else if(original_string_args[i] == "-log_level") {
-            if(i + 2 >= original_string_args.size()) {
+            if(i + 1 >= original_string_args.size()) {
                 LOG(FATAL) << Constants::usage << std::endl;
                 throw std::runtime_error("no argument after -log_level");
             }
@@ -71,12 +71,26 @@ std::vector<std::string> Util::process_args(const int argc, const char* argv[]) 
             Constants::log_level = std::stoi(std::string(argv[i + 1]));
             LOG(DEBUG) << "-log_level was found: " << Constants::log_level << std::endl;
             i += 2;
-	} else if(original_string_args[i] == "-es") {
-	    Constants::es = std::stoi(std::string(argv[i+1]));
-	    LOG(DEBUG) << "-es was found: " << Constants::es << std::endl;
-	    i += 2;
+	    } else if(original_string_args[i] == "-es") {
+            if(i + 1 >= original_string_args.size()) {
+                LOG(FATAL) << Constants::usage << std::endl;
+                throw std::runtime_error("no argument after -es");
+            }
+
+            Constants::es = std::stoi(std::string(argv[i+1]));
+            LOG(DEBUG) << "-es was found: " << Constants::es << std::endl;
+            i += 2;
+        } else if(original_string_args[i] == "-max_cacheable_byte_size") {
+            if(i + 1 >= original_string_args.size()) {
+                LOG(FATAL) << Constants::usage << std::endl;
+                throw std::runtime_error("no argument after -max_cacheable_byte_size");
+            }
+
+            Constants::max_cacheable_byte_size = std::stoi(std::string(argv[i+1]));
+            LOG(DEBUG) << "-max_cacheable_byte_size was found: " << Constants::max_cacheable_byte_size << std::endl;
+            i += 2;
         } else if(original_string_args[i] == "-log_type") {
-            if(i + 2 >= original_string_args.size()) {
+            if(i + 1 >= original_string_args.size()) {
                 LOG(FATAL) << Constants::usage << std::endl;
                 throw std::runtime_error("no argument after -log_type");
             }
@@ -85,7 +99,7 @@ std::vector<std::string> Util::process_args(const int argc, const char* argv[]) 
             LOG(DEBUG) << "-log_type was found: " << Constants::log_type << std::endl;
             i += 2;
         } else if(original_string_args[i] == "-log_output_dir") {
-            if(i + 2 >= original_string_args.size()) {
+            if(i + 1 >= original_string_args.size()) {
                 LOG(FATAL) << Constants::usage << std::endl;
                 throw std::runtime_error("no argument after -log_output_dir");
             }
@@ -158,15 +172,6 @@ std::optional<std::ofstream> Util::try_get_fstream_from_path(const char* path) {
     LOG(DEBUG) << "succesfully opened path: " << output_path_string << std::endl;
 
     return file;
-}
-
-std::string Util::get_current_datetime() {
-    const time_t now = time(nullptr);
-    char buf[80];
-    const tm tstruct = *localtime(&now);
-    strftime(buf, sizeof(buf), "%Y-%m-%d.%X", &tstruct);
-
-    return buf;
 }
 
 #define GET_FS_STREAM(path_string, filename)                                     \

--- a/src/fs/util.h
+++ b/src/fs/util.h
@@ -31,8 +31,6 @@ class Util {
 
     static std::optional<std::ofstream> try_get_fstream_from_path(const char* path);
 
-    static std::string get_current_datetime();
-
     static void log_all_metrics(const std::string& path_string);
 
     // NOTE: clears all caches and metics


### PR DESCRIPTION
Added optional parameter -max_cacheable_byte_size. If a file is larger than this, the request will be sent to Lustre instead of being cached.